### PR TITLE
chore: Updated text "export.started" for FEET export started.

### DIFF
--- a/feet/src/pages/feetpage/feetPageText.json
+++ b/feet/src/pages/feetpage/feetPageText.json
@@ -60,9 +60,9 @@
     "nn": "Noko gjekk gale, prøv igjen seinare."
   },
   "export.started": {
-    "en": "Processes running, download imminent, you impressed.",
-    "no": "Prosesser kjører, nedlasting straks, du imponert.",
-    "nn": "Prosessar køyrer, nedlasting straks, du imponert."
+    "en": "The process is rolling. What you selected is on its way! Quite impressive, don’t you think?",
+    "no": "Prosessen er i gang. Det du har valgt er på vei! Ganske imponerende, ikke sant?",
+    "nn": "Prosessen er i gang. Det du har valt er på veg! Ganske imponerande, er det ikkje?"
   },
   "export.filename.label": {
     "en": "Edit filename",


### PR DESCRIPTION
## Trello Link
[Trello card](https://trello.com/c/wgDelojf)

## Description
Updated text "export.started" for FEET export started.

## Screenshots
### Before
![Screenshot 2024-10-15 223512](https://github.com/user-attachments/assets/e02a194f-53f7-4f75-aa28-550daebe0625)

### After
![Screenshot 2024-10-15 223745](https://github.com/user-attachments/assets/f6e512e0-145f-478f-8537-6386492c9852)

## Checklist
- [ ] Tests have been written or updated:
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] End-to-end tests (if applicable)
- [ ] Accessibility has been checked:
    - [ ] Dark mode
    - [ ] Screen reader
    - [ ] Keyboard navigation
- [ ] Cross-browser testing (Chrome, Firefox, Safari, Edge)
- [ ] Responsive design verified (mobile, tablet, desktop)
- [ ] No console errors or warnings