### PR TITLE
feat: Added disclaimer to FEET and made space between checkbox and text

### DIFF
--- a/feet/src/pages/feetpage/ExportForm.module.less
+++ b/feet/src/pages/feetpage/ExportForm.module.less
@@ -13,7 +13,19 @@
 
 .checkboxContainer {
   display: flex;
-  flex-direction: row;
+
+  & input {
+    margin-right: 10px;
+  }
+
+  & label {
+    display: flex;
+    align-items: flex-start;
+  }
+
+  &:last-child {
+    margin-top: 20px;
+  }
 }
 
 .input {

--- a/feet/src/pages/feetpage/ExportForm.tsx
+++ b/feet/src/pages/feetpage/ExportForm.tsx
@@ -31,6 +31,7 @@ const ExportForm: FC = () => {
   const [address, setAddress] = useState<boolean>(true);
   const [report, setReport] = useState<boolean>(true);
   const [control, setControl] = useState<boolean>(true);
+  const [disclaimer, setDisclaimer] = useState<boolean>(false);
 
   const isZonesAvailable =
     files.length === 1 ? files[0].json.system.zones !== undefined : true;
@@ -211,10 +212,23 @@ const ExportForm: FC = () => {
           value={control}
           setValue={() => setControl(!control)}
         />
+        <li className={styles.checkboxContainer}>
+          <label>
+            <input
+              type={'checkbox'}
+              checked={disclaimer}
+              onChange={() => setDisclaimer(!disclaimer)}
+            />
+            {translate(
+              `export.disclaimer.checkbox.label` as TranslateTextKeyType,
+            )}
+          </label>
+        </li>
       </ul>
+
       <GenericButton
         className={styles.button}
-        disabled={files.length === 0 || isNoneSelected}
+        disabled={files.length === 0 || isNoneSelected || !disclaimer}
         role={'submit'}
         buttonText={translate('export.download.button')}
       />

--- a/feet/src/pages/feetpage/feetPageText.json
+++ b/feet/src/pages/feetpage/feetPageText.json
@@ -74,6 +74,11 @@
     "no": "beste-filnavnet",
     "nn": "beste-filnamnet"
   },
+  "export.disclaimer.checkbox.label": {
+    "en": "I understand this is just a tool, and that I must verify all content myself.",
+    "no": "Jeg forstår at dette bare er et verktøy, og at jeg må verifisere alt innhold selv.",
+    "nn": "Eg forstår at dette berre er eit verktøy, og at eg må verifisere alt innhald sjølv."
+  },
   "export.selectall.checkbox.label": {
     "en": "Select all",
     "no": "Velg alle",


### PR DESCRIPTION
## Trello Link
[Trello card](https://trello.com/c/SIYQ5CN6)

## Description
Added disclaimer to FEET and made a little space between checkbox list and text.

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/032f2973-5626-4c00-a406-bbf3d9016861)

### After
![Screenshot 2024-10-15 233622](https://github.com/user-attachments/assets/1fae7af0-7e77-4301-a160-f76a041a4d26)

## Checklist
- [ ] Tests have been written or updated:
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] End-to-end tests (if applicable)
- [ ] Accessibility has been checked:
    - [ ] Dark mode
    - [ ] Screen reader
    - [ ] Keyboard navigation
- [ ] Cross-browser testing (Chrome, Firefox, Safari, Edge)
- [ ] Responsive design verified (mobile, tablet, desktop)
- [ ] No console errors or warnings