### PR TITLE
chore: update success toast duration

### DIFF
--- a/feet/src/utils/useToast.tsx
+++ b/feet/src/utils/useToast.tsx
@@ -48,7 +48,7 @@ export const useToast = () => {
           hotToast.error(content, darkmodeStyles);
           break;
         case 'success':
-          hotToast.success(content, darkmodeStyles);
+          hotToast.success(content, { ...darkmodeStyles, duration: 4000 });
           break;
         case 'promise':
           if (promise !== undefined) {


### PR DESCRIPTION
Too short of a time can be hard to read, make longer for readability

## Trello Link

[Trello card](https://trello.com/c/qkRT817j)

## Description
Default duration for success toasts were 2000, the other types were 4000, made success longer to 4000 like the others.
