### PR TITLE
fix: Simplified styling in export form and resolved text overlay

### DIFF
--- a/feet/src/components/InfoBox.tsx
+++ b/feet/src/components/InfoBox.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { ReactComponent as QuestionMarkIcon } from '../assets/icons/question-mark.svg';
 import {
-    TranslateTextKeyType,
-    useLanguageContext,
+  TranslateTextKeyType,
+  useLanguageContext,
 } from '../utils/LanguageProvider';
 import { useModal } from '../utils/useModal';
 import Modal from './Modal';

--- a/feet/src/pages/feetpage/ExportForm.module.less
+++ b/feet/src/pages/feetpage/ExportForm.module.less
@@ -28,15 +28,6 @@
   }
 }
 
-.input {
-  padding: var(--spacing-xsmall);
-  border-radius: 8px;
-  margin-top: 8px;
-  background-color: var(--color-white);
-  color: var(--color-black);
-  width: 100%;
-}
-
 .list {
   padding: 0;
   margin: 0;

--- a/feet/src/pages/feetpage/ImportForm.module.less
+++ b/feet/src/pages/feetpage/ImportForm.module.less
@@ -1,6 +1,6 @@
 .uploadContainer {
   width: 100%;
-  height: 40%;
+  height: 100vh;
   border: 2px dashed;
   border-radius: 10px;
   display: flex;

--- a/feet/src/pages/feetpage/ImportForm.tsx
+++ b/feet/src/pages/feetpage/ImportForm.tsx
@@ -14,7 +14,6 @@ import { useDataContext } from '../../utils/DataProvider';
 import GenericButton from '../../components/GenericButton';
 import styles from './ImportForm.module.less';
 
-
 const FIRE_EXPERT_VERSION = '24.5';
 
 const ImportForm: FC = () => {


### PR DESCRIPTION
## Trello Link
[Trello card](https://trello.com/c/0OFnEJdV)

## Description
Simplified the styling in the export form and resolved the text overlay issue in the import form. While a more robust solution will come when we make the entire website fully responsive, this approach improves readability for now by preventing text overlap.

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/09d8fd1c-68d3-48da-bfd3-17a76411d290)

### After
![image](https://github.com/user-attachments/assets/bab93bcc-3146-4a6a-911b-73ab9edb77cb)

## Checklist
- [ ] Tests have been written or updated:
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] End-to-end tests (if applicable)
- [ ] Accessibility has been checked:
    - [ ] Dark mode
    - [ ] Screen reader
    - [ ] Keyboard navigation
- [ ] Cross-browser testing (Chrome, Firefox, Safari, Edge)
- [ ] Responsive design verified (mobile, tablet, desktop)
- [ ] No console errors or warnings