### PR TITLE
fix: Prevented file.svg from being positioned underneath long filenames.

### DIFF
--- a/feet/src/components/InfoBox.tsx
+++ b/feet/src/components/InfoBox.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { ReactComponent as QuestionMarkIcon } from '../assets/icons/question-mark.svg';
 import {
-    TranslateTextKeyType,
-    useLanguageContext,
+  TranslateTextKeyType,
+  useLanguageContext,
 } from '../utils/LanguageProvider';
 import { useModal } from '../utils/useModal';
 import Modal from './Modal';

--- a/feet/src/pages/feetpage/FileList.module.less
+++ b/feet/src/pages/feetpage/FileList.module.less
@@ -8,20 +8,21 @@
   justify-content: space-between;
   border-radius: 8px;
   display: flex;
-  flex-direction: row;
-  max-width: var(--max-width-page);
   background-color: var(--color-gray-light);
-  padding: 0 var(--spacing-small);
+  padding: 0 var(--spacing-mini);
   margin: var(--spacing-large);
+  word-break: break-all;
 
   & div {
     display: flex;
-    flex-direction: row;
+    margin: 0 var(--spacing-mini);
+    gap: var(--spacing-xsmall);
   }
 
   & svg {
     width: 24px;
     height: auto;
+    min-width: 24px;
     fill: var(--color-white);
 
     [data-theme="dark"] & {

--- a/feet/src/pages/feetpage/ImportForm.tsx
+++ b/feet/src/pages/feetpage/ImportForm.tsx
@@ -14,7 +14,6 @@ import { useDataContext } from '../../utils/DataProvider';
 import GenericButton from '../../components/GenericButton';
 import styles from './ImportForm.module.less';
 
-
 const FIRE_EXPERT_VERSION = '24.5';
 
 const ImportForm: FC = () => {


### PR DESCRIPTION
## Trello Link
[Trello card](https://trello.com/c/pVR0yTjh)

## Description
Prevented file.svg from being positioned underneath long filenames. 

## Screenshots
### Before
![Screenshot 2024-10-16 130349](https://github.com/user-attachments/assets/82a8a611-7689-4d2f-a2a5-1fbe2bc572c4)

### After
![Screenshot 2024-10-16 130831](https://github.com/user-attachments/assets/a5bccfd2-accb-4fcf-9dcc-6ea39ef1649d)

## Checklist
- [ ] Tests have been written or updated:
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] End-to-end tests (if applicable)
- [ ] Accessibility has been checked:
    - [ ] Dark mode
    - [ ] Screen reader
    - [ ] Keyboard navigation
- [ ] Cross-browser testing (Chrome, Firefox, Safari, Edge)
- [ ] Responsive design verified (mobile, tablet, desktop)
- [ ] No console errors or warnings