### PR TITLE
feat: mobile menu header

### DIFF
--- a/feet/package-lock.json
+++ b/feet/package-lock.json
@@ -32,6 +32,7 @@
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "use-local-storage": "^3.0.0",
+        "usehooks-ts": "^3.1.0",
         "web-vitals": "^2.1.4",
         "xlsx": "^0.18.5"
       },
@@ -19039,6 +19040,21 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.1"
+      }
+    },
+    "node_modules/usehooks-ts": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
+      "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=16.15.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17 || ^18"
       }
     },
     "node_modules/util-deprecate": {

--- a/feet/package.json
+++ b/feet/package.json
@@ -27,6 +27,7 @@
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "use-local-storage": "^3.0.0",
+    "usehooks-ts": "^3.1.0",
     "web-vitals": "^2.1.4",
     "xlsx": "^0.18.5"
   },

--- a/feet/src/assets/icons/burger.svg
+++ b/feet/src/assets/icons/burger.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#000000">
+    <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+    <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+    <g id="SVGRepo_iconCarrier">
+        <path d="M5 12H20" stroke="#ffffff" stroke-width="2" stroke-linecap="round"></path>
+        <path d="M5 17H20" stroke="#ffffff" stroke-width="2" stroke-linecap="round"></path>
+        <path d="M5 7H20" stroke="#ffffff" stroke-width="2" stroke-linecap="round"></path>
+    </g>
+</svg>

--- a/feet/src/components/DarkmodeToggle.module.less
+++ b/feet/src/components/DarkmodeToggle.module.less
@@ -1,8 +1,12 @@
 .darkmodeToggle {
-  display: inline-block;
-  cursor: pointer;
   background-color: unset;
-  width: 20px;
-  height: 20px;
-  margin: auto var(--spacing-small);
+  min-width: 40px;
+  height: 40px;
+  display: flex;
+
+  & svg {
+    width: 20px;
+    height: auto;
+    margin: auto;
+  }
 }

--- a/feet/src/components/GenericButton.module.less
+++ b/feet/src/components/GenericButton.module.less
@@ -1,6 +1,7 @@
 .button {
   padding: 10px 20px;
   border-radius: 5px;
+  margin: var(--spacing-xsmall);
   cursor: pointer;
   align-self: center;
   background-color: var(--color-green);

--- a/feet/src/components/GenericButton.tsx
+++ b/feet/src/components/GenericButton.tsx
@@ -3,16 +3,15 @@ import classNames from 'classnames';
 import styles from './GenericButton.module.less';
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
-  buttonText: string;
   onClick?: () => void;
   invert?: boolean;
 }
 
 const GenericButton: FC<Props> = ({
-  buttonText,
   invert,
   onClick,
   className,
+  children,
   ...buttonProps
 }) => {
   return (
@@ -23,7 +22,7 @@ const GenericButton: FC<Props> = ({
       onClick={onClick}
       {...buttonProps}
     >
-      {buttonText}
+      {children}
     </button>
   );
 };

--- a/feet/src/components/Header.module.less
+++ b/feet/src/components/Header.module.less
@@ -1,5 +1,8 @@
+@import "../utils/variables.less";
+
 .header {
   display: flex;
+  justify-content: space-between;
 }
 
 .funIcon {
@@ -8,18 +11,40 @@
   margin: var(--spacing-xsmall);
 }
 
-.menuContainer {
-  display: flex;
-  align-items: center;
-  flex-grow: 1;
-  margin-right: var(--spacing-medium);
-  padding-left: var(--spacing-medium);
-}
-
 .buttonContainer {
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: var(--spacing-xsmall);
   position: relative;
-  right: 10px;
+  margin-right: 10px;
+
+  @media @breakpoint-mobile {
+    margin-bottom: var(--spacing-large);
+  }
+}
+
+.burger {
+  width: 24px;
+  height: auto;
+}
+
+@keyframes slideInRight {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+.sidebarMenu {
+  max-height: unset;
+  height: 100%;
+  max-width: 300px;
+  border-radius: 8px 0 0 8px;
+  right: 0;
+  top: 0;
+  transition: all 1s ease-in;
+  animation: slideInRight 0.4s ease-in-out;
+
 }

--- a/feet/src/components/Header.tsx
+++ b/feet/src/components/Header.tsx
@@ -1,12 +1,20 @@
-import React from 'react';
+import { FC } from 'react';
 import { Link } from 'react-router-dom';
 import iconGenuinelyFun from '../assets/icons/icon_genuinely_fun_381x353.png';
+import { ReactComponent as BurgerIcon } from '../assets/icons/burger.svg';
+import { useModal } from '../utils/useModal';
+import { useMobileSizes } from '../utils/useMobileSizes';
+import GenericButton from './GenericButton';
 import LanguageButton from './LanguageButton';
 import DarkmodeToggle from './DarkmodeToggle';
+import Modal from './Modal';
 import Menu from './Menu';
+
 import styles from './Header.module.less';
 
-const Header: React.FC = () => {
+const Header: FC = () => {
+  const { isMobile } = useMobileSizes();
+  const menuModal = useModal();
   return (
     <header className={styles.header}>
       <Link to="/">
@@ -16,13 +24,30 @@ const Header: React.FC = () => {
           className={styles.funIcon}
         />
       </Link>
-      <div className={styles.menuContainer}>
+      {isMobile ? (
+        <GenericButton onClick={menuModal.openModal} invert={true}>
+          <BurgerIcon className={styles.burger} />
+        </GenericButton>
+      ) : (
+        <>
+          <Menu />
+          <div className={styles.buttonContainer}>
+            <DarkmodeToggle />
+            <LanguageButton />
+          </div>
+        </>
+      )}
+      <Modal
+        onClose={menuModal.closeModal}
+        isOpen={menuModal.isOpen}
+        className={styles.sidebarMenu}
+      >
+        <div className={styles.buttonContainer}>
+          <DarkmodeToggle />
+          <LanguageButton />
+        </div>
         <Menu />
-      </div>
-      <div className={styles.buttonContainer}>
-        <DarkmodeToggle />
-        <LanguageButton />
-      </div>
+      </Modal>
     </header>
   );
 };

--- a/feet/src/components/InfoBox.tsx
+++ b/feet/src/components/InfoBox.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { ReactComponent as QuestionMarkIcon } from '../assets/icons/question-mark.svg';
 import {
-    TranslateTextKeyType,
-    useLanguageContext,
+  TranslateTextKeyType,
+  useLanguageContext,
 } from '../utils/LanguageProvider';
 import { useModal } from '../utils/useModal';
 import Modal from './Modal';
@@ -36,8 +36,9 @@ const InfoBox: React.FC<InfoBoxProps> = ({ message, header, altText }) => {
         <GenericButton
           className={styles.closeButton}
           onClick={modal.closeModal}
-          buttonText={translate('close')}
-        />
+        >
+          {translate('close')}
+        </GenericButton>
       </Modal>
     </>
   );

--- a/feet/src/components/Menu.module.less
+++ b/feet/src/components/Menu.module.less
@@ -1,9 +1,20 @@
+@import "../utils/variables.less";
+
 .menu {
   display: flex;
   margin-left: auto;
-  align-items: center;
+  align-self: center;
   font-size: var(--font-size-medium);
+  margin-right: var(--spacing-medium);
+
+  @media @breakpoint-mobile {
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+
+  }
 }
+
 
 .menuButton {
   height: 100%;

--- a/feet/src/components/Menu.tsx
+++ b/feet/src/components/Menu.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import classNames from 'classnames';
+import { useWindowSize } from 'usehooks-ts';
+
 import { useLanguageContext } from '../utils/LanguageProvider';
 import DropDownMenu from './DropDownMenu';
+
 import styles from './Menu.module.less';
 
-const Menu: React.FC = () => {
+const Menu: FC<{ onLinkClick?: () => void }> = ({ onLinkClick }) => {
   const { translate } = useLanguageContext();
   const location = useLocation();
+  const { width } = useWindowSize();
 
   return (
     <nav className={styles.menu}>
@@ -16,6 +20,7 @@ const Menu: React.FC = () => {
           [styles.active]: location.pathname === '/',
         })}
         to="/"
+        onClick={onLinkClick}
       >
         {translate('tab.homepage')}
       </Link>
@@ -24,6 +29,7 @@ const Menu: React.FC = () => {
         className={classNames(styles.menuButton, {
           [styles.active]: location.pathname === '/feet',
         })}
+        onClick={onLinkClick}
       >
         {translate('tab.feet')}
       </Link>
@@ -36,6 +42,7 @@ const Menu: React.FC = () => {
               [styles.active]: location.pathname === '/dropzone',
             })}
             to="/dropzone"
+            onClick={onLinkClick}
           >
             {translate('tab.dropzone')}
           </Link>,
@@ -44,6 +51,7 @@ const Menu: React.FC = () => {
               [styles.active]: location.pathname === '/tech-best-practice',
             })}
             to="/tech-best-practice"
+            onClick={onLinkClick}
           >
             {translate('tab.tech.best.practice')}
           </Link>,
@@ -54,14 +62,3 @@ const Menu: React.FC = () => {
 };
 
 export default Menu;
-
-export const MenuText = {
-  'tab-homepage': {
-    en: 'Home',
-    no: 'Hjem',
-  },
-  'tab-feet': {
-    en: 'FEET',
-    no: 'FEET',
-  },
-};

--- a/feet/src/components/Modal.module.less
+++ b/feet/src/components/Modal.module.less
@@ -44,6 +44,10 @@
   }
 }
 
+.modalContent {
+  margin: var(--spacing-medium);
+}
+
 .closeButton {
   position: absolute;
   top: var(--spacing-small);

--- a/feet/src/components/Modal.tsx
+++ b/feet/src/components/Modal.tsx
@@ -11,14 +11,16 @@ interface Props extends PropsWithChildren {
   isOpen: boolean;
   className?: string;
   crossAriaLabel?: string;
+  overlayClassname?: string;
 }
 
 const Modal: FC<Props> = ({
+  children,
   onClose,
   isOpen,
   className,
   crossAriaLabel,
-  children,
+  overlayClassname,
 }) => {
   const { translate } = useLanguageContext();
   return (
@@ -29,7 +31,7 @@ const Modal: FC<Props> = ({
       shouldCloseOnOverlayClick={true}
       shouldFocusAfterRender={true}
       shouldReturnFocusAfterClose={true}
-      overlayClassName={styles.overlay}
+      overlayClassName={classNames(styles.overlay, overlayClassname)}
       className={classNames(styles.modal, className)}
       appElement={document.getElementById('root') as HTMLElement}
     >
@@ -41,7 +43,7 @@ const Modal: FC<Props> = ({
       >
         <CrossIcon />
       </button>
-      {children}
+      <div className={styles.modalContent}>{children}</div>
     </ReactModal>
   );
 };

--- a/feet/src/index.less
+++ b/feet/src/index.less
@@ -1,4 +1,5 @@
 :root {
+  --breakpoint-tablet: 768px;
   --max-width-page: 750px;
   --page-margin: auto auto 150px auto;
   --font-weight-light: 300;
@@ -87,4 +88,8 @@ button {
   cursor: pointer;
   font-size: var(--font-size-small);
   background-color: unset;
+}
+
+.ReactModal__Body--open {
+  overflow: hidden;
 }

--- a/feet/src/pages/feetpage/ExportForm.tsx
+++ b/feet/src/pages/feetpage/ExportForm.tsx
@@ -232,8 +232,9 @@ const ExportForm: FC = () => {
         className={styles.button}
         disabled={files.length === 0 || isNoneSelected || !disclaimer}
         role={'submit'}
-        buttonText={translate('export.download.button')}
-      />
+      >
+        {translate('export.download.button')}
+      </GenericButton>
     </form>
   );
 };

--- a/feet/src/pages/feetpage/ImportForm.tsx
+++ b/feet/src/pages/feetpage/ImportForm.tsx
@@ -14,7 +14,6 @@ import { useDataContext } from '../../utils/DataProvider';
 import GenericButton from '../../components/GenericButton';
 import styles from './ImportForm.module.less';
 
-
 const FIRE_EXPERT_VERSION = '24.5';
 
 const ImportForm: FC = () => {
@@ -163,8 +162,9 @@ const ImportForm: FC = () => {
           <GenericButton
             className={styles.uploadButton}
             onClick={() => document.getElementById('file-upload')?.click()}
-            buttonText={translate('upload.button')}
-          />
+          >
+            {translate('upload.button')}
+          </GenericButton>
         </>
       </div>
       <p>{translate('supported-version') + FIRE_EXPERT_VERSION}</p>

--- a/feet/src/pages/homepage/HomePage.tsx
+++ b/feet/src/pages/homepage/HomePage.tsx
@@ -83,9 +83,10 @@ const HomePage: FC = () => {
             <p>{translate('main-section.infobox-description')}</p>
             <GenericButton
               onClick={() => console.log('I DO NOTHING YET TODO TODO TODO')}
-              buttonText={translate('main-section.infobox-button')}
               invert={true}
-            />
+            >
+              {translate('main-section.infobox-button')}
+            </GenericButton>
           </div>
         </Card>
         <Card

--- a/feet/src/utils/useMobileSizes.tsx
+++ b/feet/src/utils/useMobileSizes.tsx
@@ -1,0 +1,10 @@
+import { useWindowSize } from 'usehooks-ts';
+
+export const useMobileSizes = () => {
+  const { width } = useWindowSize();
+  return {
+    isMobile: width <= 768,
+    isTablet: width <= 1040 && width > 768,
+    isDesktop: width > 1040,
+  };
+};

--- a/feet/src/utils/variables.less
+++ b/feet/src/utils/variables.less
@@ -1,0 +1,3 @@
+@breakpoint-mobile: ~"(max-width: 768px)";
+@breakpoint-tablet: ~"(max-width: 1040px)";
+@breakpoint-desktop: ~"(min-width: 1040px)";


### PR DESCRIPTION
## Trello Link

[Trello card](https://trello.com/c/ig6Tk7ki)

## Description
Using modal as a menu sidebar, with some simple setup for breakpoints

Updated GenericButton to take children instead of buttonText for more managability for its contents

## Screenshots

![image](https://github.com/user-attachments/assets/38b4df32-83a4-4b49-8d76-5b5ea37c392c)
![image](https://github.com/user-attachments/assets/64fb4052-f09a-4fd1-8ce3-5d63610c3e79)
![image](https://github.com/user-attachments/assets/3e8ef10c-8a6e-4aa4-9253-80dba2a5d62c)
![image](https://github.com/user-attachments/assets/59eff9fa-4176-48f7-899b-bb536678c623)

