### PR TITLE
chore: updating html lang attribute to update with page language

### DIFF
--- a/feet/src/utils/LanguageProvider.tsx
+++ b/feet/src/utils/LanguageProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, FC, PropsWithChildren } from 'react';
+import React, { createContext, FC, PropsWithChildren, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { i18n, TFunction } from 'i18next';
 
@@ -67,6 +67,10 @@ export const LanguageContextProvider: FC<PropsWithChildren> = ({
   const languages: Languages = { en: 'English', no: 'Norsk', nn: 'Nynorsk' };
 
   const { t, i18n } = useTranslation();
+
+  useEffect(() => {
+    document.querySelector('html')?.setAttribute('lang', i18n.language);
+  }, [i18n.language]);
 
   const onClickLanguageChange = (language: string) => {
     i18n.changeLanguage(language);


### PR DESCRIPTION
We should have the same language in the html as the text, will help screenreaders understand what language is displayed and read appropriately

## Screenshots

### Before
<img width="564" alt="image" src="https://github.com/user-attachments/assets/f7263528-8fb1-4cb8-b309-8dce83608402" />

### After
<img width="559" alt="image" src="https://github.com/user-attachments/assets/432bdba9-fd6c-4f13-b614-9e060ee024e4" />
