### PR TITLE
chore: Made not in use devices show on io-report and control-groups

### DIFF
--- a/frontend/src/projects/feet/utils/io-report-utils.ts
+++ b/frontend/src/projects/feet/utils/io-report-utils.ts
@@ -18,8 +18,6 @@ export const mapToIOReportToExcel = (
     const { output_function } = output_control;
     const { control, control_groups } = output_control;
 
-
-
     const otherFunctions = [];
     if (!control_groups || control_groups.length === 0) {
       if (control === 'General control') {


### PR DESCRIPTION
### **Description**
Made 'not in use' devices show on Excel io-report and control-groups, request from user

### **Changes**
- Removed filter for "not in use" that affected `io-report-utils.ts` and `control-group-report-utils.ts`

### **Question**
- First time doing this, please check extra that everything is right. I did removed entirely the line
```tsx
const isNull = (el: unknown) => el === null || el === '' || el === undefined;
```

that was linked to
```tsx
 return IOReport.filter(
    (el) =>
      !(
        (isNull(el['Input Function']) && isNull(el['Output Function'])) ||
        (el['Input Function'] === 'Not in use' &&
          isNull(el['Output Function'])) ||
        (el['Output Function'] === 'Not in use' &&
          isNull(el['Input Function'])) ||
        el['Input Function'] === 'Manual call point' ||
        el['Output Function'] === 'Manual call point'
      )
```

### **JSON file from the technician**

[configuration-fbcaed39-c9db-43d3-9697-aaefc6c64718-v29-mcu24.11.0-d17a7b15-70d5-48a9-b074-fbf183fcfc8b.json](https://github.com/user-attachments/files/21776557/configuration-fbcaed39-c9db-43d3-9697-aaefc6c64718-v29-mcu24.11.0-d17a7b15-70d5-48a9-b074-fbf183fcfc8b.json)
