### PR TITLE
fix(feet): panel filtering now works properly

### DIFF
--- a/frontend/src/pages/fs/feetpage/FeetExportForm.tsx
+++ b/frontend/src/pages/fs/feetpage/FeetExportForm.tsx
@@ -82,7 +82,7 @@ const FeetExportForm: FC = () => {
         if (filteredPanels[file.name] === undefined) {
           return true;
         }
-        return filteredPanels[file.name][panel.name];
+        return filteredPanels[file.name][`${panel.number}. ${panel.name}`];
       });
       if (separateFiles) {
         panels.forEach((panel) => {


### PR DESCRIPTION
Fixing error sent in by user. Updating panel key naming happened without where it was called. This will fix that error.