### PR TITLE
fix(feet): info message on empty sheets

### DIFF
--- a/frontend/src/pages/fs/feetpage/feetExportFormText.json
+++ b/frontend/src/pages/fs/feetpage/feetExportFormText.json
@@ -248,5 +248,15 @@
     "en": "Download Excel sheet",
     "no": "Last ned Excel filen",
     "nn": "Last ned Excel-fila"
+  },
+  "feet-export.unavailable-sheets.title": {
+    "en": "File {filename}",
+    "no": "Filen {filename}",
+    "nn": "Fila {filename}"
+  },
+  "feet-export.unavailable-sheets.desc": {
+    "en": "The following sheets are unavailable and are not included due to lack of data:",
+    "no": "Følgende ark er utilgjengelige og ikke inkludert på grunn av tom data:",
+    "nn": "Følgjande ark er utilgjengelege og ikkje inkludert på grunn av tom data:"
   }
 }

--- a/frontend/src/utils/useToast.ts
+++ b/frontend/src/utils/useToast.ts
@@ -83,6 +83,7 @@ export const useToast = (): Toast => {
         default:
           hotToast(content, {
             ...darkmodeStyles,
+            duration: 8000,
           });
           break;
       }


### PR DESCRIPTION
### **Description**
Testing for empty sheets and not adding them to the file to avoid errors. Users will now get a toast informing of this. It's not pretty, but it works.

Control Group Report sheet was added underscore to match the other sheetnames and avoid potential errors of sheetname with spaces.

Also increased info duration so users can read it all.
### **Screenshot**
<img width="623" height="234" alt="image" src="https://github.com/user-attachments/assets/df824aaf-97f0-4d39-83ac-227da1759898" />