### PR TITLE
Fix/download alert tooltip

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,14 +20,21 @@
       });
     </script>
 
-    <!-- Cookie banner -->
-    <script
-      data-culture="NO"
-      data-gcm-version="false"
-      id="CookieConsent"
-      src="https://policy.app.cookieinformation.com/uc.js"
-      type="text/javascript"
-    ></script>
+    <!-- Cookie banner (production only) -->
+    <script>
+      if (window.location.hostname !== 'localhost') {
+        var s = document.createElement('script');
+        s.setAttribute('data-culture', 'NO');
+        s.setAttribute('data-gcm-version', 'false');
+        s.setAttribute('id', 'CookieConsent');
+        s.src = 'https://policy.app.cookieinformation.com/uc.js';
+        s.type = 'text/javascript';
+        document.currentScript.parentNode.insertBefore(
+          s,
+          document.currentScript.nextSibling
+        );
+      }
+    </script>
     <!-- Google Tag Manager -->
     <script>
       (function (w, d, s, l, i) {

--- a/frontend/src/components/FeedbackBanner.module.less
+++ b/frontend/src/components/FeedbackBanner.module.less
@@ -4,11 +4,9 @@
   max-width: var(--max-width-page);
   width: 100%;
   margin: var(--spacing-large) auto;
-  padding: 0 var(--spacing-large);
 
   @media @breakpoint-tablet {
     margin: var(--spacing-large);
-    padding: 0;
   }
 }
 

--- a/frontend/src/components/FeedbackBanner.module.less
+++ b/frontend/src/components/FeedbackBanner.module.less
@@ -1,10 +1,14 @@
 @import "../utils/variables.less";
 
 .container {
+  max-width: var(--max-width-page);
+  width: 100%;
   margin: var(--spacing-large) auto;
+  padding: 0 var(--spacing-large);
 
   @media @breakpoint-tablet {
     margin: var(--spacing-large);
+    padding: 0;
   }
 }
 

--- a/frontend/src/components/FeedbackBanner.module.less
+++ b/frontend/src/components/FeedbackBanner.module.less
@@ -2,7 +2,6 @@
 
 .container {
   max-width: var(--max-width-page);
-  width: 100%;
   margin: var(--spacing-large) auto;
 
   @media @breakpoint-tablet {

--- a/frontend/src/components/FeedbackBanner.module.less
+++ b/frontend/src/components/FeedbackBanner.module.less
@@ -5,7 +5,8 @@
   margin: var(--spacing-large) auto;
 
   @media @breakpoint-tablet {
-    margin: var(--spacing-large);
+    margin: var(--spacing-large)
+      calc(var(--spacing-medium) + var(--spacing-large));
   }
 }
 

--- a/frontend/src/pages/fs/feetpage/FeetExportForm.tsx
+++ b/frontend/src/pages/fs/feetpage/FeetExportForm.tsx
@@ -248,12 +248,11 @@ const FeetExportForm: FC = () => {
                 })}
               </strong>
             </p>
-            <p>{translate('feet-export.unavailable-sheets.desc')}</p>
-            <ul>
-              {unavailableSheets.map((sheet) => (
-                <li key={sheet}>{sheet}</li>
-              ))}
-            </ul>
+            <p>
+              {translate('feet-export.unavailable-sheets.desc', {
+                sheets: unavailableSheets.join(', '),
+              })}
+            </p>
           </div>
         ),
       });

--- a/frontend/src/pages/fs/feetpage/FeetExportForm.tsx
+++ b/frontend/src/pages/fs/feetpage/FeetExportForm.tsx
@@ -240,7 +240,7 @@ const FeetExportForm: FC = () => {
       toast({
         type: 'info',
         element: (
-          <>
+          <div>
             <p>
               <strong>
                 {translate('feet-export.unavailable-sheets.title', {
@@ -254,7 +254,7 @@ const FeetExportForm: FC = () => {
                 <li key={sheet}>{sheet}</li>
               ))}
             </ul>
-          </>
+          </div>
         ),
       });
     }

--- a/frontend/src/pages/fs/feetpage/FeetExportForm.tsx
+++ b/frontend/src/pages/fs/feetpage/FeetExportForm.tsx
@@ -73,6 +73,7 @@ const FeetExportForm: FC = () => {
       });
       setFilteredPanels(paneles);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [feetFiles, isZonesAvailable, sheetLanguage]);
 
   const onExportButtonClicked: FormEventHandler<HTMLFormElement> = (e) => {
@@ -97,7 +98,7 @@ const FeetExportForm: FC = () => {
   };
 
   const exportToFiles = (file: FeetFile, panels: Panel[]) => {
-    const { name, feet } = file;
+    const { name, short, feet } = file;
     const workbook = new Workbook();
     const zones = feet.system.zones;
 
@@ -237,11 +238,13 @@ const FeetExportForm: FC = () => {
         type: 'info',
         element: (
           <>
-            <h2>
-              {translate('feet-export.unavailable-sheets.title', {
-                filename: name,
-              })}
-            </h2>
+            <p>
+              <strong>
+                {translate('feet-export.unavailable-sheets.title', {
+                  filename: short,
+                })}
+              </strong>
+            </p>
             <p>{translate('feet-export.unavailable-sheets.desc')}</p>
             <ul>
               {unavailableSheets.map((sheet) => (

--- a/frontend/src/pages/fs/feetpage/FeetExportForm.tsx
+++ b/frontend/src/pages/fs/feetpage/FeetExportForm.tsx
@@ -57,6 +57,10 @@ const FeetExportForm: FC = () => {
 
   useEffect(() => {
     updateLanguage(sheetLanguage);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sheetLanguage]);
+
+  useEffect(() => {
     if (!isZonesAvailable) {
       setZone(false);
     }
@@ -73,8 +77,7 @@ const FeetExportForm: FC = () => {
       });
       setFilteredPanels(paneles);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [feetFiles, isZonesAvailable, sheetLanguage]);
+  }, [feetFiles, isZonesAvailable]);
 
   const onExportButtonClicked: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();

--- a/frontend/src/pages/fs/feetpage/feetExportFormText.json
+++ b/frontend/src/pages/fs/feetpage/feetExportFormText.json
@@ -255,8 +255,8 @@
     "nn": "Fila {filename}"
   },
   "feet-export.unavailable-sheets.desc": {
-    "en": "The following sheets were skipped due to no data:",
-    "no": "Følgende ark ble hoppet over på grunn av manglende data:",
-    "nn": "Følgjande ark vart hoppa over på grunn av manglande data:"
+    "en": "{sheets} were skipped due to no data.",
+    "no": "{sheets} ble hoppet over på grunn av manglende data.",
+    "nn": "{sheets} vart hoppa over på grunn av manglande data."
   }
 }

--- a/frontend/src/pages/fs/feetpage/feetExportFormText.json
+++ b/frontend/src/pages/fs/feetpage/feetExportFormText.json
@@ -255,8 +255,8 @@
     "nn": "Fila {filename}"
   },
   "feet-export.unavailable-sheets.desc": {
-    "en": "The following sheets were skipped because there was no data to include:",
-    "no": "Følgende ark ble hoppet over fordi det ikke var data å inkludere:",
-    "nn": "Følgjande ark vart hoppa over fordi det ikkje var data å inkludere:"
+    "en": "The following sheets were skipped due to no data:",
+    "no": "Følgende ark ble hoppet over på grunn av manglende data:",
+    "nn": "Følgjande ark vart hoppa over på grunn av manglande data:"
   }
 }

--- a/frontend/src/pages/fs/feetpage/feetExportFormText.json
+++ b/frontend/src/pages/fs/feetpage/feetExportFormText.json
@@ -255,8 +255,8 @@
     "nn": "Fila {filename}"
   },
   "feet-export.unavailable-sheets.desc": {
-    "en": "The following sheets are unavailable and are not included due to lack of data:",
-    "no": "Følgende ark er utilgjengelige og ikke inkludert på grunn av tom data:",
-    "nn": "Følgjande ark er utilgjengelege og ikkje inkludert på grunn av tom data:"
+    "en": "The following sheets were skipped because there was no data to include:",
+    "no": "Følgende ark ble hoppet over fordi det ikke var data å inkludere:",
+    "nn": "Følgjande ark vart hoppa over fordi det ikkje var data å inkludere:"
   }
 }

--- a/frontend/src/utils/useMobileSizes.tsx
+++ b/frontend/src/utils/useMobileSizes.tsx
@@ -3,7 +3,7 @@ import { useWindowSize } from 'usehooks-ts';
 export const useMobileSizes = () => {
   const { width } = useWindowSize();
   return {
-    isMobile: width <= 768,
+    isMobile: width <= 1040,
     isTablet: width <= 1040 && width > 768,
     isDesktop: width > 1040,
     isNotDesktop: width <= 1040,


### PR DESCRIPTION
## Fixes

**Cookie consent:** Skip `uc.js` on localhost to avoid connection errors.

**Toast improvements:** 
- Show truncated filename in smaller heading
- Fix horizontal layout by wrapping content in `<div>`
- Inline sheet names dynamically in message

**Infinite re-render:** Split `useEffect` to isolate `updateLanguage` state updates from file upload deps.

**Banner alignment:** 
- Match page content width with `max-width` and `margin: auto`
- Fix tablet spacing (72px/side) to align with page container padding + margin
- Remove `width: 100%` to prevent overflow

**Mobile menu:** Extend burger menu threshold to ≤1040px (was 768px) so it shows at tablet widths.